### PR TITLE
footer mod. and css grid overwrites for supporting browsers.

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -16,12 +16,19 @@ iframe {
 }
 
 body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   min-height: 100vh;
+  margin: 0;
   &:not(.dark) {
     background-color: transparent !important;
     .dark-only {
       display: none;
     }
+  }
+  label.form-check-label {
+    line-height: 2;
+    padding-left: 1rem;
   }
   &.dark {
     background-color: #333 !important;
@@ -45,6 +52,83 @@ body {
     }
     .light-only {
       display: none;
+    }
+  }
+}
+
+@supports (display: grid) {
+  @media screen {
+    body{
+      display:grid!important;
+      grid-template-columns: 1fr;
+      grid-gap: 2rem;
+      grid-template-areas: "a" "b" "c";
+      grid-template-rows: min-content minmax(min-content, auto) min-content;
+      & > nav{
+        grid-area: a;
+        display:grid!important;
+        grid-gap: .3em .3em;
+        grid-template-columns: 2fr 5fr;
+        ul {
+          margin: 0;
+          list-style-type: none;
+          padding: 0 0 0 1.4em;
+        }
+      }
+      &.dark > .container > .row h3{
+        color: #ddd;
+      }
+      & > .container{
+        grid-area: b;
+        align-self:center;
+        max-width: 1300px!important;
+      }
+      & > footer{
+        grid-area: c;
+        margin: 0!important;
+        min-height:initial!important;
+        position:unset!important;
+        padding: 12px!important;
+        right:initial!important;
+        bottom:initial!important;
+        left:initial!important;
+        .copyright{
+          margin-top: 10px!important;
+          padding: 12px!important;
+        }
+      }
+      & > .container > .row:not(.justify-content-center){
+        display:grid;
+        grid: auto-flow / 1fr;
+        grid-gap: 1rem .5rem;
+        @media (min-width: 600px){
+          grid: auto-flow / 1fr 1fr;
+        }
+        @media (min-width: 880px){
+          grid: auto-flow / 1fr 1fr 1fr;
+        }
+        @media (min-width: 1160px){
+          grid: auto-flow / 1fr 1fr 1fr 1fr;
+        }
+        & > div.col-md-3 {
+          flex: initial!important;
+          max-width: initial!important;
+          align-self: end;
+          text-align: center;
+          &:hover {
+            filter: brightness(110%) drop-shadow(8px 8px 10px gray);
+          }
+         }
+        h3 {
+          max-width: 100%;
+          width: 13rem;
+          white-space: nowrap;
+          margin: 0 auto!important;
+          line-height: 1.3!important;
+          text-overflow: ellipsis;
+          overflow: hidden;
+        }
+      }
     }
   }
 }

--- a/resources/views/includes/footer.blade.php
+++ b/resources/views/includes/footer.blade.php
@@ -6,25 +6,11 @@
 
     footer {
         overflow-x: hidden;
-        position: relative;
-        float: left;
         width: 100%;
-        min-height: 40vh;
         background: var(--footer-background-color);
         color: #999;
-        padding: 32px 12px;
+        padding: 20px;
         box-sizing: border-box;
-    }
-    footer .logo {
-        height: 100%;
-    }
-    footer .logo img {
-        width:100%;
-        position: relative;
-        top: 50%;
-        transform: translateY(-50%);
-        margin: 0 auto;
-        min-width: 128px;
     }
     footer h3 {
         color: #fff;
@@ -46,7 +32,7 @@
         background: white;
     }
     footer ul {
-        margin-top: 24px;
+        margin-top: 18px;
         list-style: none;
         padding: 0;
     }
@@ -78,25 +64,16 @@
         width: 80%;
     }
     footer .copyright {
-        margin-top: 32px;
+        margin-top: 20px;
         font-family: Arial, Helvetica, sans-serif;
-        padding: 24px 12px;
+        padding: 12px;
         border-top: 1px solid rgba(255, 255, 255, .2);
         text-align: center;
     }
 
-
-
     @media only screen and (max-width: 1161px) {
         footer .col-md {
             padding: 0 1.5em;
-            width: 50% !important;
-            flex-basis: unset;
-        }
-
-        footer .logo img {
-            width: 50%;
-            min-width: 128px;
         }
 
         footer .pc-only {
@@ -108,27 +85,22 @@
     }
 
 </style>
-<footer class="uk-margin-large-top">
+<footer>
     <div class="row justify-content-center">
-        <div class="col-xs-12 col-sm-12 col-md-8 col-lg-8 footer-content">
+        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 footer-content">
             <div class="row">
-                <div class="col-md-4">
-                    <div class="logo" style="width: 50%; margin: 0 auto;">
-                        <img src="{{asset('images/coderdojo_logo_white.png')}}" alt="Coderdojo">
-                    </div>
-                </div>
-                <div class="col-md-4">
-                    <h3>Informatie</h3>
+                <div class="col-md-6">
+                    <h3>Links</h3>
                     <ul>
                         <li class="nowrap"><a href="https://www.facebook.com/groups/635078973250800/" target="_blank">Facebook-pagina</a></li>
                         <li class="nowrap"><a href="https://github.com/Reflex2468/CoolestProjects2019" target="_blank">GitHub-pagina</a></li>
                         <li class="nowrap"><a href="https://www.coolestprojects.be/" target="_blank">Coolest Projects</a></li>
                     </ul>
                 </div>
-                <div class="col-md-4">
-                    <h3>Made by</h3>
+                <div class="col-md-6">
+                    <h3>Gemaakt door</h3>
                     <ul>
-                        <li>Deze site is gemaakt door Coderdojo Eeklo <br>Neal&nbsp;Joos, Xavier&nbsp;Coppens & Bart&nbsp;De&nbsp;Roy</span></li>
+                        <li>Neal&nbsp;Joos, Xavier&nbsp;Coppens & Bart&nbsp;De&nbsp;Roy</span></li>
                     </ul>
                 </div>
             </div>
@@ -138,13 +110,3 @@
         </div>
     </div>
 </footer>
-
-<script>
-
-    window.onload = function() {
-        if ($(window).height() > ($('nav').height() + $('.container').height() + $('footer').height() ) ) {
-            $('footer').addClass('uk-position-bottom');
-        }
-    }
-
-</script>


### PR DESCRIPTION
ik heb in `@supports (display: grid) { ... }` een paar dingen van bootstrap en uikit overschreven om het gebruik van [css grid layout](https://caniuse.com/#search=grid) te testen, zowel header/content/footer hun plaats te geven, als voor de projecten in `.container`.

wat ik deed om te testen:

```sh
mysql -u cdj -p coolestprojects < ~/downloads/coolestprojects.sql
git fetch --all
git checkout grid
artisan up
npm run dev
php -S localhost:8080 --docroot=public &>/dev/null &
```
